### PR TITLE
Initial fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM xblock-sdk
+FROM jbarciauskas/xblock-sdk
 RUN mkdir -p /usr/local/src/xblock-quote-of-the-day
 VOLUME ["/usr/local/src/xblock-quote-of-the-day"]
 RUN echo "pip install -e /usr/local/src/xblock-quote-of-the-day" >> /usr/local/src/xblock-sdk/install_and_run_xblock.sh

--- a/quote_of_the_day/.gitignore
+++ b/quote_of_the_day/.gitignore
@@ -1,0 +1,60 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# virtualenv
+.venv/
+venv/
+ENV/
+
+# IDE
+.idea


### PR DESCRIPTION
XBlock cookiecutter template comes with a couple of glitches - in this PR we fix them.

# Missing .gitignore

Gitignore files contain instructions to Git version control system to ignore files or folders and exclude them from what's stored in version controls. 

There are three major categories of such files:

* Auxiliary files/folders generated by other tools (i.e. IDE config folders, virtualenv)
* Files generated by runtime (i.e. *.pyc) or other development tools (coverage data, build distributions)
* Runtime and test artifacts (logs, test databases etc.)

# Fixing docker base image

[Docker](https://www.docker.com/what-docker) is a tool that allows you to combine your application and it's environment in a so called "container" - and deploy it virtually anywhere the same way it would work on your local machine. This solves many issues in operations and development... provided that you know how to cook docker.